### PR TITLE
Feature/services dependency requirements

### DIFF
--- a/lib/slayer/service.rb
+++ b/lib/slayer/service.rb
@@ -12,6 +12,9 @@ module Slayer
       raise ServiceDependencyError.new("There were duplicate dependencies in #{self}") unless deps.uniq.length == deps.length
 
       @deps = deps
+
+      # Calculate the transitive dependencies and throw an error if there are circular dependencies
+      transitive_dependencies
     end
 
     private

--- a/lib/slayer/service.rb
+++ b/lib/slayer/service.rb
@@ -1,81 +1,8 @@
 module Slayer
   class Service
-    def self.before_each_method name
-      @@allowed_services ||= nil
-
-      # Is Allowed?
-
-      if !@@allowed_services
-        # If allowed services is not set, this is the _first_ call to a service object.
-        # That's always allowed
-
-        # YES
-        puts "ALLOWED"
-      else
-        # Peek at the array of allowed services and make sure we're in it
-        allowed = @@allowed_services.last
-        if allowed && allowed.include?(self)
-          # If we are in the set of allowed services, this has been explicitly approved.
-          #YES
-          puts "ALLOWED"
-        else
-          #NO
-          raise ServiceDependencyError.new("Attempted to call #{self} from another #{Slayer::Service} which did not declare it as a dependency")
-        end
-      end
-
-      @@allowed_services ||= []
-      @@allowed_services << transitive_dependencies
-    end
-
-    def self.after_each_method name
-      @@allowed_services.pop
-      p [:after_method, name, self]
-
-      if @@allowed_services.empty?
-        @@allowed_services = nil
-      end
-
-      p @@allowed_services
-    end
-
-    def self.singleton_method_added name
-      return if self == Slayer::Service
-      return if @__last_methods_added && @__last_methods_added.include?(name)
-
-      p [:singleton_method_added, name, self]
-
-      with = :"#{name}_with_before_each_method"
-      without = :"#{name}_without_before_each_method"
-
-      @__last_methods_added = [name, with, without]
-      define_singleton_method with do |*args, &block|
-        before_each_method name
-        begin
-          send without, *args, &block
-        rescue
-          raise
-        ensure
-          after_each_method name
-        end
-      end
-
-      # p self
-      # p methods - Object.methods
-
-      singleton_class.send(:alias_method, without, name)
-
-      # p methods - Object.methods
-
-      singleton_class.send(:alias_method, name, with) # alias_method name, with
-
-      # p methods - Object.methods
-
-      @__last_methods_added = nil
-    end
 
     def self.dependencies(*deps)
-      raise ServiceDependencyError.new("There were multiple dependencies calls of #{self}") if @dependencies
+      raise ServiceDependencyError.new("There were multiple dependencies calls of #{self}") if @deps
 
       deps.each{ |dep|
         raise ServiceDependencyError.new("The object #{dep} passed to dependencies service was not a class")       unless dep.is_a?(Class)
@@ -84,13 +11,15 @@ module Slayer
 
       raise ServiceDependencyError.new("There were duplicate dependencies in #{self}") unless deps.uniq.length == deps.length
 
-      @dependencies = deps
+      @deps = deps
     end
+
+    private
 
     def self.transitive_dependencies(dependency_hash = {}, visited = [])
       return @transitive_dependencies if @transitive_dependencies
 
-      @dependencies ||= []
+      @deps ||= []
 
       # If we've already visited ourself, bail out. This is necessary to halt
       # execution for a circular chain of dependencies. #halting-problem-solved
@@ -104,7 +33,7 @@ module Slayer
       # Add each of our dependencies (and it's transitive dependency chain) to our
       # own dependencies.
 
-      @dependencies.each { |dep|
+      @deps.each { |dep|
         dependency_hash[self] << dep
 
         if !visited.include?(dep)
@@ -124,6 +53,85 @@ module Slayer
       @transitive_dependencies = dependency_hash[self]
 
       return @transitive_dependencies
+    end
+
+    def self.before_each_method name
+      @deps ||= []
+      @@allowed_services ||= nil
+
+      # Confirm that this method call is allowed
+      raise_if_not_allowed
+
+      @@allowed_services ||= []
+      @@allowed_services << @deps
+    end
+
+    def self.raise_if_not_allowed
+      if @@allowed_services
+        allowed = @@allowed_services.last
+        if !allowed || !allowed.include?(self)
+          raise ServiceDependencyError.new("Attempted to call #{self} from another #{Slayer::Service} which did not declare it as a dependency")
+        end
+      end
+    end
+
+    def self.after_each_method name
+      @@allowed_services.pop
+      @@allowed_services = nil if @@allowed_services.empty?
+    end
+
+    def self.singleton_method_added name
+      return if self == Slayer::Service
+      return if @__last_methods_added && @__last_methods_added.include?(name)
+
+      with = :"#{name}_with_before_each_method"
+      without = :"#{name}_without_before_each_method"
+
+      @__last_methods_added = [name, with, without]
+      define_singleton_method with do |*args, &block|
+        before_each_method name
+        begin
+          send without, *args, &block
+        rescue
+          raise
+        ensure
+          after_each_method name
+        end
+      end
+
+      singleton_class.send(:alias_method, without, name)
+      singleton_class.send(:alias_method, name, with)
+
+      @__last_methods_added = nil
+    end
+
+    def self.method_added name
+      return if self == Slayer::Service
+      return if @__last_methods_added && @__last_methods_added.include?(name)
+
+      with = :"#{name}_with_before_each_method"
+      without = :"#{name}_without_before_each_method"
+
+      @__last_methods_added = [name, with, without]
+      define_method with do |*args, &block|
+        self.class.before_each_method name
+        begin
+          send without, *args, &block
+        rescue
+          raise
+        ensure
+          self.class.after_each_method name
+        end
+      end
+
+      alias_method without, name
+      alias_method name, with
+
+      @__last_methods_added = nil
+    end
+
+    def self.deps
+      @deps
     end
   end
 end

--- a/test/fixtures/transitive_services.rb
+++ b/test/fixtures/transitive_services.rb
@@ -7,15 +7,15 @@ end
 class BService < Slayer::Service
     dependencies AService
 
-    def self.return_10; AService.return_5 * 2; end
-
-    def return_6; @a ||= AService.new; @a.return_3 * 2; end
+    def self.return_10; AService.return_5 * 2;     end
+    def return_6;       AService.new.return_3 * 2; end
+    def return_15;      AService.return_5 * 3;     end
 end
 
 class CService < Slayer::Service
     dependencies BService
 
-    def self.return_11; BService.return_10 + 1; end
-
-    def return_7; @b ||= BService.new; @b.return_6 + 1; end
+    def self.return_11; BService.return_10 + 1;    end
+    def self.return_8;  BService.new.return_6 + 2; end
+    def return_7;       BService.new.return_6 + 1; end
 end

--- a/test/fixtures/transitive_services.rb
+++ b/test/fixtures/transitive_services.rb
@@ -1,0 +1,21 @@
+class AService < Slayer::Service
+    def self.return_5; 5; end
+
+    def return_3; 3; end
+end
+
+class BService < Slayer::Service
+    dependencies AService
+
+    def self.return_10; AService.return_5 * 2; end
+
+    def return_6; @a ||= AService.new; @a.return_3 * 2; end
+end
+
+class CService < Slayer::Service
+    dependencies BService
+
+    def self.return_11; BService.return_10 + 1; end
+
+    def return_7; @b ||= BService.new; @b.return_6 + 1; end
+end

--- a/test/lib/command_test.rb
+++ b/test/lib/command_test.rb
@@ -61,7 +61,7 @@ class Slayer::CommandTest < Minitest::Test
   def test_result_has_expected_properties_on_fail
     result = ArgCommand.call(arg: nil)
 
-    assert_equal result.result, nil
+    assert_nil result.result
     refute result.success?
   end
 

--- a/test/service_test.rb
+++ b/test/service_test.rb
@@ -8,19 +8,19 @@ class Slayer::ServiceTest < Minitest::Test
     Class.new(Slayer::Service) { }
   end
 
-  def test_dependencies_with_no_class_raises
+  def test_raises_error_for_invalid_dependencies
     assert_raises Slayer::ServiceDependencyError do
       Class.new(Slayer::Service) { dependencies(:b_service) }
     end
   end
 
-  def test_dependencies_with_non_service_class_raises
+  def test_raises_error_for_non_service_class_dependencies
     assert_raises Slayer::ServiceDependencyError do
       Class.new(Slayer::Service) { dependencies(Slayer::Command) }
     end
   end
 
-  def test_multiple_dependencies_raises
+  def test_raises_error_for_multiple_dependencies
     assert_raises Slayer::ServiceDependencyError do
       service = Class.new(Slayer::Service)
       Class.new(Slayer::Service) { dependencies(service); dependencies(service); }
@@ -36,7 +36,7 @@ class Slayer::ServiceTest < Minitest::Test
     end
   end
 
-  def test_duplicate_dependencies_raises
+  def test_raises_error_for_duplicate_dependencies
     assert_raises Slayer::ServiceDependencyError do
       service = Class.new(Slayer::Service)
       Class.new(Slayer::Service) { dependencies(service, service) }
@@ -44,7 +44,7 @@ class Slayer::ServiceTest < Minitest::Test
   end
 
   # Transitive and Circular Dependencies
-  def test_circular_dependencies_raises
+  def test_raises_error_for_circular_dependencies
     s(:FirstService) {
       s(:SecondService) {
         SecondService.dependencies FirstService
@@ -61,18 +61,18 @@ class Slayer::ServiceTest < Minitest::Test
   end
 
   # Dependency Enforcements
-  def test_service_instance_can_be_called_from_anywhere
+  def test_instance_calls_allowed_from_non_service_class
     assert_equal AService.new.return_3, 3, "AService instance should directly produce the result of 3"
   end
 
-  def test_service_instance_can_be_called_if_listed_in_dependencies
+  def test_instance_calls_allowed_when_in_dependencies
     assert_equal BService.new.return_6, 6,   "BService instance should've produced the result of 6 using AService instance"
     assert_equal CService.return_8, 8, "BService instance should've produced the result of 15 using AService"
     assert_equal BService.new.return_15, 15, "BService instance should've produced the result of 15 using AService"
 
   end
 
-  def test_instance_raises_exception_if_service_calls_another_service_not_listed_in_dependencies
+  def test_raises_error_for_disallowed_call_from_instance
     s(:NoDependencyListedService,
       Proc.new { def do_no_dependency_thing; AService.return_5 * 3; end }) {
 
@@ -90,15 +90,15 @@ class Slayer::ServiceTest < Minitest::Test
     }
   end
 
-  def test_service_can_be_called_from_anywhere
+  def test_calls_allowed_from_non_service_class
     assert_equal AService.return_5, 5, "AService should directly produce the result of 5"
   end
 
-  def test_service_can_be_called_if_listed_in_dependencies
+  def test_calls_allowed_when_in_dependencies
     assert_equal BService.return_10, 10, "BService should've produced the result of 10 using AService"
   end
 
-  def test_raises_exception_if_service_calls_another_service_not_listed_in_dependencies
+  def test_raises_error_for_disallowed_call
     s(:NoDependencyListedService,
       Proc.new { def self.do_no_dependency_thing; AService.return_5 * 3; end }) {
 

--- a/test/service_test.rb
+++ b/test/service_test.rb
@@ -48,10 +48,9 @@ class Slayer::ServiceTest < Minitest::Test
     s(:FirstService) {
       s(:SecondService) {
         SecondService.dependencies FirstService
-        FirstService.dependencies  SecondService
 
         assert_raises Slayer::ServiceDependencyError do
-          FirstService.transitive_dependencies
+          FirstService.dependencies  SecondService
         end
       }
     }

--- a/test/service_test.rb
+++ b/test/service_test.rb
@@ -2,73 +2,104 @@ require 'test_helper'
 require 'set'
 
 class Slayer::ServiceTest < Minitest::Test
-  # class AService < Slayer::Service; end
-  # class BService < Slayer::Service; dependencies AService; end
-  # class CService < Slayer::Service; dependencies :BService; end
-
   # Dependencies
   def test_empty_dependencies_doesnt_raise
-    a_service = Class.new(Slayer::Service) { dependencies() }
+    Class.new(Slayer::Service) { dependencies() }
+    Class.new(Slayer::Service) { }
   end
 
   def test_dependencies_with_no_class_raises
     assert_raises Slayer::ServiceDependencyError do
-      a_service = Class.new(Slayer::Service) { dependencies(:b_service) }
+      Class.new(Slayer::Service) { dependencies(:b_service) }
     end
   end
 
   def test_dependencies_with_non_service_class_raises
     assert_raises Slayer::ServiceDependencyError do
-      a_service = Class.new(Slayer::Service) { dependencies(Slayer::Command) }
+      Class.new(Slayer::Service) { dependencies(Slayer::Command) }
     end
   end
 
   def test_multiple_dependencies_raises
     assert_raises Slayer::ServiceDependencyError do
-      a_service = Class.new(Slayer::Service)
-      b_service = Class.new(Slayer::Service) { dependencies(a_service); dependencies(a_service); }
+      service = Class.new(Slayer::Service)
+      Class.new(Slayer::Service) { dependencies(service); dependencies(service); }
     end
 
     assert_raises Slayer::ServiceDependencyError do
-      a_service = Class.new(Slayer::Service) { dependencies; dependencies;}
+      Class.new(Slayer::Service) { dependencies; dependencies;}
     end
 
     assert_raises Slayer::ServiceDependencyError do
-      a_service = Class.new(Slayer::Service)
-      b_service = Class.new(Slayer::Service) { dependencies; dependencies(a_service); }
+      service = Class.new(Slayer::Service)
+      Class.new(Slayer::Service) { dependencies; dependencies(service); }
     end
   end
 
   def test_duplicate_dependencies_raises
     assert_raises Slayer::ServiceDependencyError do
-      a_service = Class.new(Slayer::Service)
-      b_service = Class.new(Slayer::Service) { dependencies(a_service, a_service) }
+      service = Class.new(Slayer::Service)
+      Class.new(Slayer::Service) { dependencies(service, service) }
     end
   end
 
   # Transitive and Circular Dependencies
   def test_circular_dependencies_raises
-    a_service = Class.new(Slayer::Service)
-    b_service = Class.new(Slayer::Service) { dependencies(a_service) }
+    s(:FirstService) {
+      s(:SecondService) {
+        SecondService.dependencies FirstService
+        FirstService.dependencies  SecondService
 
-    a_service.dependencies(b_service)
-
-    assert_raises Slayer::ServiceDependencyError do
-      a_service.transitive_dependencies
-    end
+        assert_raises Slayer::ServiceDependencyError do
+          FirstService.transitive_dependencies
+        end
+      }
+    }
   end
 
   def test_transitive_dependency_chain
-    a_service = Class.new(Slayer::Service)
-    b_service = Class.new(Slayer::Service) { dependencies(a_service); }
-    c_service = Class.new(Slayer::Service) { dependencies(b_service); }
+    assert_array_contents_equal CService.transitive_dependencies, [BService, AService]
+  end
 
-    assert_array_contents_equal c_service.transitive_dependencies, [b_service, a_service]
+  def test_service_can_be_called_from_anywhere
+    assert_equal AService.return_5, 5, "AService should directly produce the result of 5"
+  end
+
+  def test_service_can_be_called_if_listed_in_dependencies
+    assert_equal BService.return_10, 10, "BService should've produced the result of 10 using AService"
+  end
+
+  def test_raises_exception_if_service_calls_another_service_not_listed_in_dependencies
+    s(:NoDependencyListedService,
+      Proc.new { def self.do_no_dependency_thing; AService.return_5 * 3; end }) {
+
+      assert_raises Slayer::ServiceDependencyError, "Should not be able to call AService if it's not listed as a dependency" do
+        NoDependencyListedService.do_no_dependency_thing
+      end
+    }
   end
 
   private
+  def s(name, service_block = nil, &block)
+    create_service(name: name, &service_block)
+
+    yield
+
+    cleanup_service(name: name)
+  end
+
+  def create_service(name: nil, &block)
+    return Class.new(Slayer::Service, &block).tap{ |service|
+      Object.const_set(name, service) if name
+    }
+  end
+
+  def cleanup_service(name: nil)
+    Object.send(:remove_const, name)
+  end
+
   def assert_array_contents_equal(actual, expected, message = nil)
-    actual_set = Set.new actual
+    actual_set   = Set.new actual
     expected_set = Set.new expected
 
     assert_equal actual_set, expected_set, message


### PR DESCRIPTION
Adds method hooks for all service method calls (both class methods and instance methods).

The method hooks check to ensure that the method call is "allowed", where method calls are "allowed" if they come: From non-service classes, OR, from service classes with the dependency explicitly listed.

Note that the "allowed" check will essentially check the last Service that exists up the call stack (so using an intermediary class will not fool the called Service class into thinking it is allowed).
