### PR TITLE
PROOF OF CONCEPT: Commands with fibers

### DIFF
--- a/lib/slayer/errors.rb
+++ b/lib/slayer/errors.rb
@@ -1,12 +1,12 @@
 module Slayer
-  class CommandFailureError < StandardError
-    attr_reader :result
-
-    def initialize(result)
-      @result = result
-      super
-    end
-  end
+  # class CommandFailureError < StandardError
+  #   attr_reader :result
+  #
+  #   def initialize(result)
+  #     @result = result
+  #     super
+  #   end
+  # end
 
   class CommandNotImplementedError < StandardError
     def initialize(message = nil)

--- a/lib/slayer/result.rb
+++ b/lib/slayer/result.rb
@@ -16,9 +16,8 @@ module Slayer
       @failure || false
     end
 
-    def fail!
+    def fail
       @failure = true
-      raise CommandFailureError, self
     end
   end
 end

--- a/test/lib/command_test.rb
+++ b/test/lib/command_test.rb
@@ -146,12 +146,6 @@ class Slayer::CommandTest < Minitest::Test
     assert result.failure?
   end
 
-  def test_raises_error_for_run_with_exceptions_flag
-    assert_raises Slayer::CommandFailureError do
-      ArgCommand.call!(arg: nil)
-    end
-  end
-
   def test_raises_error_for_incorrect_args
     assert_raises ArgumentError do
       ArgCommand.call(bar: 'arg')

--- a/test/lib/result_matcher_test.rb
+++ b/test/lib/result_matcher_test.rb
@@ -256,15 +256,9 @@ class Slayer::ResultMatcherTest < Minitest::Test
       Slayer::ResultMatcher.new(result, NoArgCommand.new)
     end
 
-    # We intentionally capture the Slayer::CommandFailureError here
-    # as we are intentionally accessing a matcher with a failed
-    # result for testing in isolation.
     def matcher_with_fail_result(status: :default)
       result = Slayer::Result.new(5, status, 'my message')
-      begin
-        result.fail!
-      rescue Slayer::CommandFailureError
-      end
+      result.fail
 
       Slayer::ResultMatcher.new(result, NoArgCommand.new)
     end


### PR DESCRIPTION
**DO NOT MERGE, PROOF OF CONCEPT ONLY**

The following code is not the decided way of handling command result objects, fails Rubocop, and needs further cleanup.

This is a proof of concept only, intended to demonstrate a viable implementation of Commands using Fibers.