### PR TITLE
Issue 39 pass fail cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 /tmp/
 /log*/*
 .byebug_history
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -133,9 +133,9 @@ Slayer Commands should implement `call`, which will `pass` or `fail` the service
 class FooCommand < Slayer::Command
   def call(foo:)
     if foo == "foo"
-      pass! value: foo, message: "Passing FooCommand"
+      return pass value: foo, message: "Passing FooCommand"
     else
-      fail! value: foo, message: "Failing FooCommand"
+      return fail value: foo, message: "Failing FooCommand"
     end
   end
 end

--- a/lib/slayer/command.rb
+++ b/lib/slayer/command.rb
@@ -8,10 +8,6 @@ module Slayer
         execute_call(block, *args) { |c, *a| c.run(*a) }
       end
 
-      def call!(*args, &block)
-        execute_call(block, *args) { |c, *a| c.run!(*a) }
-      end
-
       private
 
       def execute_call(command_block, *args)
@@ -48,11 +44,6 @@ module Slayer
       call(*args)
     rescue ResultFailureError
       # Swallow the Command Failure
-    end
-
-    # Run the Command
-    def run!(*args)
-      call(*args)
     end
 
     # Create a passing Result

--- a/lib/slayer/command.rb
+++ b/lib/slayer/command.rb
@@ -47,18 +47,18 @@ module Slayer
     end
 
     # Create a passing Result
-    def pass(value: nil, status: :default, message: nil)
+    def ok(value: nil, status: :default, message: nil)
       @result = Result.new(value, status, message)
     end
 
     # Create a failing Result
-    def fail(value: nil, status: :default, message: nil)
+    def err(value: nil, status: :default, message: nil)
       @result = Result.new(value, status, message).fail
     end
 
     # Create a failing Result and halt execution of the Command
-    def fail!(value: nil, status: :default, message: nil)
-      fail(value: value, status: status, message: message)
+    def err!(value: nil, status: :default, message: nil)
+      err(value: value, status: status, message: message)
       raise ResultFailureError, self
     end
 
@@ -67,9 +67,9 @@ module Slayer
     # of the Command.
     def try!(value: nil, status: nil, message: nil)
       r = yield
-      fail!(value: value, status: status || :default, message: message) unless r.kind_of?(Result)
+      err!(value: value, status: status || :default, message: message) unless r.is_a?(Result)
       return r.value if r.success?
-      fail!(value: value || r.value, status: status || r.status, message: message || r.message)
+      err!(value: value || r.value, status: status || r.status, message: message || r.message)
     end
 
     # Call the command

--- a/lib/slayer/command.rb
+++ b/lib/slayer/command.rb
@@ -47,18 +47,18 @@ module Slayer
     end
 
     # Create a passing Result
-    def ok(value: nil, status: :default, message: nil)
+    def pass(value: nil, status: :default, message: nil)
       @result = Result.new(value, status, message)
     end
 
     # Create a failing Result
-    def err(value: nil, status: :default, message: nil)
+    def flunk(value: nil, status: :default, message: nil)
       @result = Result.new(value, status, message).fail
     end
 
     # Create a failing Result and halt execution of the Command
-    def err!(value: nil, status: :default, message: nil)
-      err(value: value, status: status, message: message)
+    def flunk!(value: nil, status: :default, message: nil)
+      flunk(value: value, status: status, message: message)
       raise ResultFailureError, self
     end
 
@@ -67,9 +67,9 @@ module Slayer
     # of the Command.
     def try!(value: nil, status: nil, message: nil)
       r = yield
-      err!(value: value, status: status || :default, message: message) unless r.is_a?(Result)
+      flunk!(value: value, status: status || :default, message: message) unless r.is_a?(Result)
       return r.value if r.success?
-      err!(value: value || r.value, status: status || r.status, message: message || r.message)
+      flunk!(value: value || r.value, status: status || r.status, message: message || r.message)
     end
 
     # Call the command

--- a/lib/slayer/errors.rb
+++ b/lib/slayer/errors.rb
@@ -10,8 +10,7 @@ module Slayer
 
   class CommandNotImplementedError < StandardError
     def initialize(message = nil)
-      message ||= 'Command implementation must call `fail!` or `pass!`, or '\
-                  'return a <Slayer::Result> object'
+      message ||= 'Command implementation must return a <Slayer::Result> object'
       super message
     end
   end

--- a/lib/slayer/errors.rb
+++ b/lib/slayer/errors.rb
@@ -1,5 +1,5 @@
 module Slayer
-  class CommandFailureError < StandardError
+  class ResultFailureError < StandardError
     attr_reader :result
 
     def initialize(result)

--- a/lib/slayer/result.rb
+++ b/lib/slayer/result.rb
@@ -16,9 +16,9 @@ module Slayer
       @failure || false
     end
 
-    def fail!
+    def fail
       @failure = true
-      raise CommandFailureError, self
+      self
     end
   end
 end

--- a/test/fixtures/commands/arg_command.rb
+++ b/test/fixtures/commands/arg_command.rb
@@ -1,9 +1,9 @@
 class ArgCommand < Slayer::Command
   def call(arg: nil)
     if !arg.nil?
-      return pass value: arg
+      return ok value: arg
     else
-      return fail value: arg
+      return err value: arg
     end
   end
 end

--- a/test/fixtures/commands/arg_command.rb
+++ b/test/fixtures/commands/arg_command.rb
@@ -1,9 +1,9 @@
 class ArgCommand < Slayer::Command
   def call(arg: nil)
     if !arg.nil?
-      pass! value: arg
+      return pass value: arg
     else
-      fail! value: arg
+      return fail value: arg
     end
   end
 end

--- a/test/fixtures/commands/arg_command.rb
+++ b/test/fixtures/commands/arg_command.rb
@@ -1,9 +1,7 @@
 class ArgCommand < Slayer::Command
   def call(arg: nil)
-    if !arg.nil?
-      return ok value: arg
-    else
-      return err value: arg
-    end
+    flunk! value: arg if arg.nil?
+
+    pass value: arg
   end
 end

--- a/test/fixtures/commands/no_arg_command.rb
+++ b/test/fixtures/commands/no_arg_command.rb
@@ -1,5 +1,5 @@
 class NoArgCommand < Slayer::Command
   def call
-    pass! value: 'pass'
+    pass value: 'pass'
   end
 end

--- a/test/fixtures/commands/no_arg_command.rb
+++ b/test/fixtures/commands/no_arg_command.rb
@@ -1,5 +1,5 @@
 class NoArgCommand < Slayer::Command
   def call
-    pass value: 'pass'
+    ok value: 'pass'
   end
 end

--- a/test/fixtures/commands/no_arg_command.rb
+++ b/test/fixtures/commands/no_arg_command.rb
@@ -1,5 +1,5 @@
 class NoArgCommand < Slayer::Command
   def call
-    ok value: 'pass'
+    pass value: 'pass'
   end
 end

--- a/test/fixtures/commands/no_result_command.rb
+++ b/test/fixtures/commands/no_result_command.rb
@@ -1,9 +1,9 @@
 class NoResultCommand < Slayer::Command
   def call(should_pass: true)
     if should_pass
-      pass!
+      return pass
     else
-      fail!
+      return fail
     end
   end
 end

--- a/test/fixtures/commands/no_result_command.rb
+++ b/test/fixtures/commands/no_result_command.rb
@@ -1,9 +1,9 @@
 class NoResultCommand < Slayer::Command
   def call(should_pass: true)
     if should_pass
-      return pass
+      return ok
     else
-      return fail
+      return err
     end
   end
 end

--- a/test/fixtures/commands/no_result_command.rb
+++ b/test/fixtures/commands/no_result_command.rb
@@ -1,9 +1,9 @@
 class NoResultCommand < Slayer::Command
   def call(should_pass: true)
     if should_pass
-      return ok
+      return pass
     else
-      return err
+      return flunk
     end
   end
 end

--- a/test/fixtures/commands/try_command.rb
+++ b/test/fixtures/commands/try_command.rb
@@ -1,10 +1,10 @@
 class TryCommand < Slayer::Command
   def call(value:, succeed: false)
     v = try! do
-      next ok value: value if succeed
-      next err value: value unless succeed
+      next pass value: value if succeed
+      next flunk value: value unless succeed
     end
 
-    return ok value: v
+    pass value: v
   end
 end

--- a/test/fixtures/commands/try_command.rb
+++ b/test/fixtures/commands/try_command.rb
@@ -1,0 +1,10 @@
+class TryCommand < Slayer::Command
+  def call(value:, succeed: false)
+    v = try! do
+      next pass value: value if succeed
+      next fail value: value unless succeed
+    end
+
+    return pass value: v
+  end
+end

--- a/test/fixtures/commands/try_command.rb
+++ b/test/fixtures/commands/try_command.rb
@@ -1,10 +1,10 @@
 class TryCommand < Slayer::Command
   def call(value:, succeed: false)
     v = try! do
-      next pass value: value if succeed
-      next fail value: value unless succeed
+      next ok value: value if succeed
+      next err value: value unless succeed
     end
 
-    return pass value: v
+    return ok value: v
   end
 end

--- a/test/lib/command_test.rb
+++ b/test/lib/command_test.rb
@@ -79,6 +79,14 @@ class Slayer::CommandTest < Minitest::Test
     end
   end
 
+  def test_raises_if_all_defaults_not_handled
+    assert_raises do
+      ArgCommand.call(arg: 'arg') do |r|
+        r.pass { }
+      end
+    end
+  end
+
   def test_value_result_and_command_available_in_block
     NoArgCommand.call do |m|
       m.all do |value, result, command|

--- a/test/lib/command_test.rb
+++ b/test/lib/command_test.rb
@@ -147,7 +147,7 @@ class Slayer::CommandTest < Minitest::Test
   end
 
   def test_raises_error_for_run_with_exceptions_flag
-    assert_raises Slayer::CommandFailureError do
+    assert_raises Slayer::ResultFailureError do
       ArgCommand.call!(arg: nil)
     end
   end

--- a/test/lib/command_test.rb
+++ b/test/lib/command_test.rb
@@ -82,7 +82,7 @@ class Slayer::CommandTest < Minitest::Test
   def test_raises_if_all_defaults_not_handled
     assert_raises do
       ArgCommand.call(arg: 'arg') do |r|
-        r.pass { }
+        r.pass {}
       end
     end
   end

--- a/test/lib/command_test.rb
+++ b/test/lib/command_test.rb
@@ -10,11 +10,6 @@ class Slayer::CommandTest < Minitest::Test
     NoArgCommand.call
   end
 
-  def test_instantiates_and_calls_with_exceptions_flag
-    NoArgCommand.expects(:call!).once
-    NoArgCommand.call!
-  end
-
   # Implementation Tests
   # ---------------------------------------------
   #
@@ -127,13 +122,6 @@ class Slayer::CommandTest < Minitest::Test
     assert result.success?
   end
 
-  def test_can_be_run_with_exceptions_flag
-    result = ArgCommand.call!(arg: 'arg')
-
-    assert_equal result.value, 'arg'
-    assert result.success?
-  end
-
   def test_can_call_pass_with_no_result
     result = NoResultCommand.call(should_pass: true)
 
@@ -144,12 +132,6 @@ class Slayer::CommandTest < Minitest::Test
 
     assert_nil result.value
     assert result.failure?
-  end
-
-  def test_raises_error_for_run_with_exceptions_flag
-    assert_raises Slayer::ResultFailureError do
-      ArgCommand.call!(arg: nil)
-    end
   end
 
   def test_raises_error_for_incorrect_args

--- a/test/lib/command_test.rb
+++ b/test/lib/command_test.rb
@@ -149,4 +149,15 @@ class Slayer::CommandTest < Minitest::Test
       InvalidCommand.call
     end
   end
+
+  def test_try_bubbles_up_error
+    assert TryCommand.call(value: :my_value, succeed: false).failure?
+  end
+
+  def test_try_returns_value
+    result = TryCommand.call(value: :my_value, succeed: true)
+
+    assert result.success?
+    assert_equal :my_value, result.value
+  end
 end

--- a/test/lib/result_matcher_test.rb
+++ b/test/lib/result_matcher_test.rb
@@ -256,14 +256,14 @@ class Slayer::ResultMatcherTest < Minitest::Test
       Slayer::ResultMatcher.new(result, NoArgCommand.new)
     end
 
-    # We intentionally capture the Slayer::CommandFailureError here
+    # We intentionally capture the Slayer::ResultFailureError here
     # as we are intentionally accessing a matcher with a failed
     # result for testing in isolation.
     def matcher_with_fail_result(status: :default)
       result = Slayer::Result.new(5, status, 'my message')
       begin
         result.fail!
-      rescue Slayer::CommandFailureError
+      rescue Slayer::ResultFailureError
       end
 
       Slayer::ResultMatcher.new(result, NoArgCommand.new)

--- a/test/lib/result_matcher_test.rb
+++ b/test/lib/result_matcher_test.rb
@@ -260,11 +260,7 @@ class Slayer::ResultMatcherTest < Minitest::Test
     # as we are intentionally accessing a matcher with a failed
     # result for testing in isolation.
     def matcher_with_fail_result(status: :default)
-      result = Slayer::Result.new(5, status, 'my message')
-      begin
-        result.fail!
-      rescue Slayer::ResultFailureError
-      end
+      result = Slayer::Result.new(5, status, 'my message').fail
 
       Slayer::ResultMatcher.new(result, NoArgCommand.new)
     end


### PR DESCRIPTION
Renames `pass!` to `pass`
Renames `fail!` to `flunk!`
Creates `flunk` which is like `flunk!` but does not halt execution
Creates `try!` which returns the value for the block if it is a successful result, and fails otherwise.