### PR TITLE
Feature/wip add cops

### DIFF
--- a/lib/slayer/cops/return_matcher.rb
+++ b/lib/slayer/cops/return_matcher.rb
@@ -1,0 +1,43 @@
+require 'rubocop'
+
+module Slayer
+  class CommandReturn < RuboCop::Cop::Base
+    def_node_search :explicit_returns, 'return'
+    def_node_matcher :slayer_command?, "(class (const (const nil :Slayer) :Command) _)"
+    def_node_matcher :is_call_to_pass?, "(send nil :pass ?)"
+    def_node_matcher :is_call_to_flunk?, "(send nil :flunk! ?)"
+
+    def on_def(node)
+      return unless node.method?(:call)
+      return unless in_slayer_command?(node)
+
+      explicit_returns(node) do |node|
+        validate_return! node.child_nodes.first, node
+      end
+
+      return # Temporarily does not look at implicit returns
+      implicit_returns(node) do |node|
+        validate_return! node
+      end
+    end
+
+    private
+
+    # Continue traversing `node` until you get to the last expression.
+    # If that expression is a call to `.can_see?`, then add an offense.
+    def implicit_returns(node)
+      raise "Not Implemented Yet"
+    end
+
+    def in_slayer_command?(node)
+      node.ancestors.any? &:slayer_command?
+    end
+
+    def validate_return!(node, return_node = nil)
+      return if is_call_to_pass? node
+      return if is_call_to_flunk? node
+
+      add_offense(return_node || node, message: "call in Slayer::Command must return the result of `pass` or call `flunk!`")
+    end
+  end
+end


### PR DESCRIPTION
This is a first (WIP) pass at adding a Rubocop Cop for validating the return of a Command. I'd also love to see:

 - Do not override `pass`
 - Do not override `flunk!` as they'd be pretty cheap.

I'm not convinced I'm doing this right. It seems likely that there's some easy way to validate what class you're in before doing any matching....but 🤷 